### PR TITLE
fix: reCAPTCHA attribution and site-key guard

### DIFF
--- a/src/sections/Contact.tsx
+++ b/src/sections/Contact.tsx
@@ -260,6 +260,9 @@ const ContactForm = () => {
             />
           )}
         </button>
+        <p className="mt-3 text-xs text-white-600/70">
+          This site is protected by reCAPTCHA.
+        </p>
       </form>
     </>
   );


### PR DESCRIPTION
## Summary
- Add a minimal muted notice under the contact form submit button: "This site is protected by reCAPTCHA."
- Compensates for the hidden reCAPTCHA badge per Google’s attribution guidance.

## Test plan
- [ ] Contact form still submits as before
- [ ] Attribution appears under the submit button
- [ ] Attribution stays low-contrast and does not disrupt layout

Made with [Cursor](https://cursor.com)